### PR TITLE
Events show renovation

### DIFF
--- a/app/components/events/todo/list_component.rb
+++ b/app/components/events/todo/list_component.rb
@@ -8,4 +8,9 @@ class Events::Todo::ListComponent < ViewComponent::Base
     @unfinished_tasks = event.tasks.unfinished
     @finished_tasks = event.tasks.finished
   end
+
+  # このコンポーネントをレンダリングする条件
+  def render?
+    @current_user.present?  # ユーザーがログインしている場合のみ表示
+  end
 end

--- a/app/components/events/todo/login_prompt_component.html.erb
+++ b/app/components/events/todo/login_prompt_component.html.erb
@@ -1,0 +1,7 @@
+<div class="card mb-4 shadow-sm">
+  <div class="card-body text-center py-4">
+    <p class="mb-3">ToDoリストを表示するには、ログインしてください。</p>
+    <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+    <%= link_to "新規登録", new_user_registration_path, class: "btn btn-outline-primary ms-2" %>
+  </div>
+</div>

--- a/app/components/events/todo/login_prompt_component.rb
+++ b/app/components/events/todo/login_prompt_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Events::Todo::LoginPromptComponent < ViewComponent::Base
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,12 @@ class EventsController < ApplicationController
   def show
     @event = Event.find(params[:id])
     @clipboard_text = @event.formatted_text_for_clipboard
+    # ログイン状態に応じて表示するコンポーネントを決定
+    @todo_component = if user_signed_in?
+                        Events::Todo::ListComponent.new(event: @event, current_user: current_user)
+                      else
+                        Events::Todo::LoginPromptComponent.new
+                      end
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -16,9 +16,9 @@ class EventsController < ApplicationController
     # ログイン状態に応じて表示するコンポーネントを決定
     @todo_component = if user_signed_in?
                         Events::Todo::ListComponent.new(event: @event, current_user: current_user)
-                      else
+    else
                         Events::Todo::LoginPromptComponent.new
-                      end
+    end
   end
 
   def new

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -34,7 +34,7 @@
       </div>
       
       <!-- TODOリストカード -->
-      <%= render(Events::Todo::ListComponent.new(event: @event, current_user: current_user)) %>
+      <%= render @todo_component %>
       
       <!-- 戻るボタン -->
       <div class="mb-4">

--- a/test/components/events/todo/login_prompt_component_test.rb
+++ b/test/components/events/todo/login_prompt_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Events::Todo::LoginPromptComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Events::Todo::LoginPromptComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end


### PR DESCRIPTION
# 概要

<!-- タスクのURL。なければ次の行を削除してください -->
Notion: 

<!-- デザインのURL。なければ次の行を削除してください -->
Figma: 

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->
ログインをしているかしていなかで、詳細画面のToDoの表示が変わるように変更しました。

これにより、ユーザーの新規登録を促せるようになりました。


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app/components/events/todo/list_component.rbにrenderメソッドを追加しました
- "docker compose exec web rails generate component Events::Todo::LoginPrompt"を実行しコンポーネントを作成しました
以下コンポーネントのコード（クラスファイルのほうは）特に記載を行っていません
```
<div class="card mb-4 shadow-sm">
  <div class="card-body text-center py-4">
    <p class="mb-3">ToDoリストを表示するには、ログインしてください。</p>
    <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
    <%= link_to "新規登録", new_user_registration_path, class: "btn btn-outline-primary ms-2" %>
  </div>
</div>
```
- eventsコントローラーに”@todo_component = if user_signed_in?”と条件分岐を追加しました
- view側をシンプルになるよう改修しました

## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->

|       | Before | After |
| :---: | :----: | :---: |
|  |  |  |


# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->


# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
* [ ] 


# その他

<!-- レビュアーへのメッセージや一言などあれば -->
